### PR TITLE
Add setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*sanity_checker.egg-info
+*py[co]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup
+
+setup(
+    name='sanity-checker',
+    version='0.0.1',
+    py_modules='sanity_check',
+    package_dir={'': 'files'},
+    license='AGPL',
+)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,15 @@
+"""
+This repository is not only an ansible role, but also a home of a python module
+named `sanity_check`. The reason for that is that I needed to have the same checks
+installable as an ansible role, and as a view in [dalite-ng][1]. I decided
+not to copy the code, but find the way to share it between the two,
+and this was the least bad way do do it.
+
+[1]: https://github.com/open-craft/dalite-ng
+"""
+
 from distutils.core import setup
+
 
 setup(
     name='sanity-checker',


### PR DESCRIPTION
This PR adds `setup.py` file that installs `sanity_checker` module to local interpreter, this is used by dalite to install file-system checks. 

This might look unituitive, but this is only sane way that allows me to share this code (apart from copy-pasting). 
