### PR TITLE
Install mailutils package.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
-# tasks file for sanity-check
+- name: install mailutils apt package
+  apt:
+    name: mailutils
+
 - name: copy sanity check script
   copy: src=sanity_check.py dest={{ SANITY_CHECK_SCRIPT_LOCATION }} mode=500
 


### PR DESCRIPTION
This package is required by the sanity checker, and seems to be implicitly installed on all our servers so far.  However, it does not seem to be included in current minimal Xenial images, so we should explicitly install it here.