### PR TITLE
Report the output of arbitrary commands.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from distutils.core import setup
 
 setup(
     name='sanity-checker',
-    version='0.0.1',
+    version='0.1.0',
     py_modules=['sanity_check'],
     package_dir={'': 'files'},
     license='AGPL',


### PR DESCRIPTION
Right now, we can't glean any useful information from running an arbitrary command, except if it passed or not.

This PR makes arbitrary sanity check commands log their full output to the sanity check report, so we know what's actually going on.

To test, install the requirements into a virtualenv, cd to the tests directory and run

    python -m unittest test_sanity_check
